### PR TITLE
improve mpv-menu-plugin support

### DIFF
--- a/recentmenu.lua
+++ b/recentmenu.lua
@@ -20,6 +20,7 @@ local menu = {
 
 local dyn_menu = {
     ready = false,
+    script_name = 'dyn_menu',
     type = 'submenu',
     submenu = {}
 }
@@ -301,7 +302,7 @@ function update_dyn_menu_items()
         }
     end
     dyn_menu.submenu = submenu
-    mp.commandv('script-message-to', 'dyn_menu', 'update', 'recent', utils.format_json(dyn_menu))
+    mp.commandv('script-message-to', dyn_menu.script_name, 'update', 'recent', utils.format_json(dyn_menu))
 end
 
 function play_last()
@@ -358,7 +359,8 @@ mp.register_script_message('uosc-locale', function(json)
     menu.title = t(menu.title)
 end)
 
-mp.register_script_message('menu-ready', function()
+mp.register_script_message('menu-ready', function(script_name)
     dyn_menu.ready = true
+    dyn_menu.script_name = script_name
     update_dyn_menu_items()
 end)


### PR DESCRIPTION
[`dyn_menu.lua`在广播`menu-ready`消息的时候带上了脚本名](https://github.com/tsl0922/mpv-menu-plugin/blob/2704a977b8b0b48bd09659c73ee26243e8798eb2/src/lua/dyn_menu.lua#L545-L546)，应该使用这个脚本名发送消息，以适应脚本被重命名的情况

MPV_lazy就是改过名的 hooke007/MPV_lazy@5c26025
